### PR TITLE
Initialize colorama for enhanced color support

### DIFF
--- a/cookie_converter.py
+++ b/cookie_converter.py
@@ -2,8 +2,9 @@ import json
 import os
 import shutil
 import sys
-from colorama import Fore
+from colorama import init, Fore
 
+init()
 
 def identify_file(file_name):
     try:

--- a/main.py
+++ b/main.py
@@ -5,7 +5,9 @@ import asyncio
 import time
 import aiohttp
 from bs4 import BeautifulSoup
-from colorama import Fore
+from colorama import init, Fore
+
+init()
 
 print(Fore.YELLOW + "Initializing!, Please wait...\n" + Fore.RESET)
 working_cookies_path = "working_cookies"


### PR DESCRIPTION
Add ```init()``` function from Colorama to enable color support across different terminal environments.